### PR TITLE
Prevent 'taskhash mismatch' errors during UBI creation

### DIFF
--- a/conf/machine/include/et7000mini.inc
+++ b/conf/machine/include/et7000mini.inc
@@ -38,23 +38,25 @@ UBI_VOLNAME = "rootfs"
 MKUBIFS_ARGS = "-m 2048 -e 126976 -c 8192"
 UBINIZE_ARGS = "-m 2048 -p 128KiB"
 
-#IMAGEDIR ?= "${MACHINE}"
 IMAGEDIR ?= "et7x00"
 IMGDEPLOYDIR ?= "${DEPLOY_DIR_IMAGE}"
 
+IMAGEVERSION := "${DISTRO_NAME}-${DISTRO_VERSION}-${DATE}"
+IMAGEVERSION[vardepsexclude] = "DATE"
+
 IMAGE_CMD_ubi_append = " \
 	mkdir -p ${IMGDEPLOYDIR}/${IMAGEDIR}; \
- 	cp -f ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ubi ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.bin; \
- 	gzip -9c ${DEPLOY_DIR_IMAGE}/vmlinux-${MACHINE}.bin > ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
- 	echo ${DISTRO_NAME}-${DISTRO_VERSION}-${DATE} > ${IMGDEPLOYDIR}/${IMAGEDIR}/imageversion; \
- 	echo "rename this file to 'force' to force an update without confirmation" > ${IMGDEPLOYDIR}/${IMAGEDIR}/noforce; \
- 	cd ${IMGDEPLOYDIR}; \	
+	cp -f ${IMGDEPLOYDIR}/${IMAGE_NAME}.rootfs.ubi ${IMGDEPLOYDIR}/${IMAGEDIR}/rootfs.bin; \
+	gzip -9c ${DEPLOY_DIR_IMAGE}/vmlinux-${MACHINE}.bin > ${IMGDEPLOYDIR}/${IMAGEDIR}/kernel.bin; \
+	echo "${IMAGEVERSION}" > ${IMGDEPLOYDIR}/${IMAGEDIR}/imageversion; \
+	echo "rename this file to 'force' to force an update without confirmation" > ${IMGDEPLOYDIR}/${IMAGEDIR}/noforce; \
+	cd ${IMGDEPLOYDIR}; \
 	zip ${DISTRO_NAME}-${DISTRO_VERSION}-${MACHINE}_usb.zip ${IMAGEDIR}/*; \
 	rm -rf ${IMAGEDIR}; \
 	"
 IMAGE_CMD_ubi_prepend = " \
-        rm -rf ${IMAGE_ROOTFS}/tmp/*; \
-        "
+	rm -rf ${IMAGE_ROOTFS}/tmp/*; \
+"
 
 MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec"
 


### PR DESCRIPTION
The recipe writes the current DATE to a file. This may evaluate to
a different value in a subprocess, e.g. due to locale settings.
To work around that, put the date stamp into a variable at parse time
and exclude it from dependency parsing.
 
This should solve the occasional "taskhash mismatch" errors that
occur while building.
 
Based on: https://github.com/XTrendTeam/meta-xtrend/commit/5c01ba739442f38655ef45047a27bba94d061dd0

Cosmetic changes in et7000mini.inc
No code changes, only remove spaces and unused