### PR TITLE
Add 7seg in et1x000 MACHINE_FEATURES

### DIFF
--- a/conf/machine/et1x000.conf
+++ b/conf/machine/et1x000.conf
@@ -8,7 +8,7 @@ IMAGE_INSTALL_append += "\
     initrd-${MACHINE} \
     "
 
-MACHINE_FEATURES += "mmc"
+MACHINE_FEATURES += "mmc 7seg"
 
 CHIPSET = "bcm7251s"
 

--- a/conf/machine/et1x000.conf
+++ b/conf/machine/et1x000.conf
@@ -8,7 +8,7 @@ IMAGE_INSTALL_append += "\
     initrd-${MACHINE} \
     "
 
-MACHINE_FEATURES += "mmc 7seg"
+MACHINE_FEATURES += "mmc 7segment"
 
 CHIPSET = "bcm7251s"
 


### PR DESCRIPTION
This allow use 7segment skin for display.
The driver also supports letters on the display, but it seems to me that the 4 character display is not suitable for channel names or menu text.